### PR TITLE
update website to refer to avian-pack project

### DIFF
--- a/_includes/download.md
+++ b/_includes/download.md
@@ -31,6 +31,6 @@ Major features:
 * The Android class library is has neither a proprietary, nor a copyleft-style license, thus may be freely used and embedded in both proprietary and open-source projects, and may also be modified freely (the authors would be happy for any pull requests submitted).  Most non-Avian additional components are released under Apache license (the same as Android itself); others are mostly BSD.
 * The library has been pached to support Microsoft Windows, which was a major challenge, especially sockets and other I/O.
 
-[Avian-pack v0.1 (pre-release) with Avian 1.2.0 provided](https://github.com/bigfatbrowncat/avian-pack/releases/tag/v0.1-1.2.0)
+[Download Avian-pack v0.1 (pre-release) with Avian 1.2.0 provided](https://github.com/bigfatbrowncat/avian-pack/releases/tag/v0.1-1.2.0)
 
 Avian-pack is an independent project maintained by its creators: [@bigfatbrowncat](https://github.com/bigfatbrowncat) and [@JustAMan](https://github.com/JustAMan).  Please report issues and questions to that project.

--- a/_includes/download.md
+++ b/_includes/download.md
@@ -16,3 +16,21 @@ Recent changes:
 * Improve compatibility with OpenJDK 8 class library
 * Improve compatibility with Android class library
 * Improve Gradle build support
+
+### Avian-Pack Project (Avian plus Android class library)
+
+This is a project for building Avian with the Android class library, providing more complete support for functionality such as regular expressions, SSL, localization, etc..  It does not include any Android platform support such as UI and system components.
+
+All the components are patched to work on Windows and OS X (while the vanilla Android classpath is Linux-only) and tested (a bit).  There are some minor known issues that hopefully will be fixed in the next releases.
+
+[Avian-pack project page on GitHub](https://github.com/bigfatbrowncat/avian-pack)
+
+Major features:
+
+* All-in-one. Many simple Java projects and libraries should already work with this package (if they don't, you are welcome to [submit an issue](https://github.com/bigfatbrowncat/avian-pack/issues).)
+* The Android class library is has neither a proprietary, nor a copyleft-style license, thus may be freely used and embedded in both proprietary and open-source projects, and may also be modified freely (the authors would be happy for any pull requests submitted).  Most non-Avian additional components are released under Apache license (the same as Android itself); others are mostly BSD.
+* The library has been pached to support Microsoft Windows, which was a major challenge, especially sockets and other I/O.
+
+[Avian-pack v0.1 (pre-release) with Avian 1.2.0 provided](https://github.com/bigfatbrowncat/avian-pack/releases/tag/v0.1-1.2.0)
+
+Avian-pack is an independent project maintained by its creators: [@bigfatbrowncat](https://github.com/bigfatbrowncat) and [@JustAMan](https://github.com/JustAMan).  Please report issues and questions to that project.


### PR DESCRIPTION
This is a version of https://github.com/ReadyTalk/avian/pull/439, edited for clarity and converted from HTML to Markdown.